### PR TITLE
[local] Create dd release github action

### DIFF
--- a/.github/workflows/release-dd.yml
+++ b/.github/workflows/release-dd.yml
@@ -1,0 +1,86 @@
+name: Datadog Release
+
+on:
+  push:
+    tags:
+     - v*
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - build-os: linux
+            build-arch: amd64
+            build-linker: x86-64
+          - build-os: linux
+            build-arch: arm64
+            build-linker: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.5"
+      - name: cache go mod
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ matrix.build-os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ matrix.build-os }}-go
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            tools/optimizer-server/target/
+          key: ${{ matrix.build-os }}-cargo-${{ hashFiles('tools/optimizer-server/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build-os }}-cargo
+      - name: install gnu gcc linker
+        run: |
+          if [ "${{ matrix.build-linker }}" != "static" ]; then
+            sudo apt-get install -qq gcc-${{ matrix.build-linker }}-linux-gnu
+          fi
+      - name: build nydus-snapshotter and optimizer
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+          export PATH=$PATH:$(go env GOPATH)/bin
+          if [ "${{ matrix.build-arch }}" == "static" ]; then
+            make static-package
+          else
+            make package GOOS=${{ matrix.build-os }} GOARCH=${{ matrix.build-arch }}
+          fi
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-tars-${{ matrix.build-os }}-${{ matrix.build-arch }}
+          path: |
+            package/*.tar.gz*
+          overwrite: true
+  upload:
+    runs-on: ubuntu-22.04
+    needs: [build]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: builds
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "Nydus Snapshotter ${{ github.ref_name }} Datadog Release"
+          generate_release_notes: true
+          files: |
+            builds/release-tars-**/*


### PR DESCRIPTION
Basically the same from upstream but with archs we don't use removed and without the bits pushing a docker image. Also change the release tag to match `v*`.

Tested with v0.0.0-test tag:
- job https://github.com/DataDog/nydus-snapshotter/actions/runs/17094372166
- final release https://github.com/DataDog/nydus-snapshotter/releases/tag/v0.0.0-test