### PR TITLE
[index] Add OCI index detection for Nydus alternatives

### DIFF
--- a/.github/workflows/k8s-e2e-run.yml
+++ b/.github/workflows/k8s-e2e-run.yml
@@ -19,3 +19,9 @@ jobs:
     uses: ./.github/workflows/k8s-e2e.yml
     with:
       auth-type: kubeconf
+
+  index_detect:
+    uses: ./.github/workflows/k8s-e2e.yml
+    with:
+      auth-type: kubeconf
+      index-detect: true

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -6,6 +6,9 @@ on:
       auth-type:
         required: true
         type: string
+      index-detect:
+        required: false
+        type: boolean
 
 env:
   DOCKER_USER: testuser
@@ -28,7 +31,8 @@ jobs:
           cache-dependency-path: "go.sum"
       - name: Test
         run: |
-          AUTH_TYPE='${{ inputs.auth-type }}'
+          export AUTH_TYPE='${{ inputs.auth-type }}'
+          export INDEX_DETECT='${{ inputs.index-detect }}'
           ./tests/helpers/kind.sh
       - name: Dump logs
         if: failure()

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ const (
 type Experimental struct {
 	EnableStargz         bool        `toml:"enable_stargz"`
 	EnableReferrerDetect bool        `toml:"enable_referrer_detect"`
+	EnableIndexDetect    bool        `toml:"enable_index_detect"`
 	TarfsConfig          TarfsConfig `toml:"tarfs"`
 	EnableBackendSource  bool        `toml:"enable_backend_source"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		Experimental: Experimental{
 			EnableStargz:         false,
 			EnableReferrerDetect: false,
+			EnableIndexDetect:    false,
 		},
 		CleanupOnClose: false,
 		SystemControllerConfig: SystemControllerConfig{

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -9,6 +9,7 @@ package filesystem
 
 import (
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
+	"github.com/containerd/nydus-snapshotter/pkg/index"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
@@ -56,6 +57,17 @@ func WithReferrerManager(rm *referrer.Manager) NewFSOpt {
 		}
 
 		fs.referrerMgr = rm
+		return nil
+	}
+}
+
+func WithIndexManager(im *index.Manager) NewFSOpt {
+	return func(fs *Filesystem) error {
+		if im == nil {
+			return errors.New("index manager cannot be nil")
+		}
+
+		fs.indexMgr = im
 		return nil
 	}
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	racache "github.com/containerd/nydus-snapshotter/pkg/rafs"
+	"github.com/containerd/nydus-snapshotter/pkg/index"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/stargz"
@@ -46,6 +47,7 @@ type Filesystem struct {
 	enabledManagers      map[string]*manager.Manager
 	cacheMgr             *cache.Manager
 	referrerMgr          *referrer.Manager
+	indexMgr             *index.Manager
 	stargzResolver       *stargz.Resolver
 	tarfsMgr             *tarfs.Manager
 	verifier             *signature.Verifier

--- a/pkg/filesystem/index_adaptor.go
+++ b/pkg/filesystem/index_adaptor.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"context"
+	"fmt"
+
+	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+func (fs *Filesystem) IndexDetectEnabled() bool {
+	return fs.indexMgr != nil
+}
+
+// CheckIndexAlternative attempts to find a nydus alternative manifest in the original OCI index manifest
+func (fs *Filesystem) CheckIndexAlternative(ctx context.Context, labels map[string]string) bool {
+	if !fs.IndexDetectEnabled() {
+		return false
+	}
+
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return false
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if manifestDigest.Validate() != nil {
+		return false
+	}
+
+	log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String()).Debug("attempting index-based nydus detection")
+	if _, err := fs.indexMgr.CheckIndexAlternative(ctx, ref, manifestDigest); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// TryFetchMetadataFromIndex attempts to fetch metadata from the nydus index alternative
+func (fs *Filesystem) TryFetchMetadataFromIndex(ctx context.Context, labels map[string]string, metadataPath string) error {
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return fmt.Errorf("empty label %s", snpkg.TargetRefLabel)
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if err := manifestDigest.Validate(); err != nil {
+		return fmt.Errorf("invalid label %s=%s", snpkg.TargetManifestDigestLabel, manifestDigest)
+	}
+
+	if err := fs.indexMgr.TryFetchMetadata(ctx, ref, manifestDigest, metadataPath); err != nil {
+		return errors.Wrap(err, "try fetch metadata")
+	}
+
+	return nil
+}

--- a/pkg/index/detector.go
+++ b/pkg/index/detector.go
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/containerd/nydus-snapshotter/pkg/remote"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// Containerd restricts the max size of manifest index to 8M, follow it.
+const maxManifestIndexSize = 0x800000
+const metadataNameInLayer = "image/image.boot"
+const nydusOSFeature = "nydus.remoteimage.v1"
+
+type detector struct {
+	remote *remote.Remote
+}
+
+func newDetector(keyChain *auth.PassKeyChain, insecure bool) *detector {
+	return &detector{
+		remote: remote.New(keyChain, insecure),
+	}
+}
+
+// checkIndexAlternative attempts to find a nydus alternative manifest
+// within an OCI index manifest for the specified manifest digest.
+func (d *detector) checkIndexAlternative(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {
+	handle := func() (*ocispec.Descriptor, error) {
+		// Create a new fetcher to request.
+		fetcher, err := d.remote.Fetcher(ctx, ref)
+		if err != nil {
+			return nil, errors.Wrap(err, "get fetcher")
+		}
+
+		resolver := d.remote.Resolve(ctx, ref)
+		_, desc, err := resolver.Resolve(ctx, ref)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolve reference %s", ref)
+		}
+
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch index manifest")
+		}
+		defer rc.Close()
+
+		// Parse image manifest list from index.
+		var index ocispec.Index
+		bytes, err := io.ReadAll(io.LimitReader(rc, maxManifestIndexSize))
+		if err != nil {
+			return nil, errors.Wrap(err, "read index manifest")
+		}
+		if err := json.Unmarshal(bytes, &index); err != nil {
+			return nil, errors.Wrap(err, "unmarshal index manifest")
+		}
+
+		nydusDesc, err := d.findNydusManifestInIndex(index, manifestDigest)
+		if err != nil {
+			return nil, err
+		}
+
+		rc, err = fetcher.Fetch(ctx, *nydusDesc)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch nydus image manifest")
+		}
+		defer rc.Close()
+
+		var manifest ocispec.Manifest
+		bytes, err = io.ReadAll(rc)
+		if err != nil {
+			return nil, errors.Wrap(err, "read manifest")
+		}
+		if err := json.Unmarshal(bytes, &manifest); err != nil {
+			return nil, errors.Wrap(err, "unmarshal manifest")
+		}
+		if len(manifest.Layers) < 1 {
+			return nil, fmt.Errorf("invalid manifest")
+		}
+		metaLayer := manifest.Layers[len(manifest.Layers)-1]
+		if !label.IsNydusMetaLayer(metaLayer.Annotations) {
+			return nil, fmt.Errorf("invalid nydus manifest")
+		}
+
+		return &metaLayer, nil
+	}
+
+	desc, err := handle()
+	if err != nil && d.remote.RetryWithPlainHTTP(ref, err) {
+		return handle()
+	}
+
+	return desc, err
+}
+
+// findNydusManifestInIndex finds a nydus alternative manifest within an OCI index
+// for the specified manifest digest. It returns the nydus manifest descriptor.
+func (d *detector) findNydusManifestInIndex(index ocispec.Index, originalDigest digest.Digest) (*ocispec.Descriptor, error) {
+	var originalDesc *ocispec.Descriptor
+	for _, manifest := range index.Manifests {
+		if manifest.Digest == originalDigest {
+			originalDesc = &manifest
+			break
+		}
+	}
+	if originalDesc == nil {
+		return nil, fmt.Errorf("manifest %s not found in index", originalDigest)
+	}
+
+	pMatcher := platforms.NewMatcher(*originalDesc.Platform)
+	for _, manifest := range index.Manifests {
+		if d.hasNydusFeatures(manifest.Platform) && pMatcher.Match(*manifest.Platform) {
+			return &manifest, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no nydus alternative found in index for %s", originalDigest)
+}
+
+// hasNydusFeatures checks if the platform descriptor contains nydus features.
+func (d *detector) hasNydusFeatures(platform *ocispec.Platform) bool {
+	if platform == nil {
+		return false
+	}
+
+	return slices.Contains(platform.OSFeatures, nydusOSFeature)
+}
+
+// fetchMetadata fetches and unpacks nydus metadata file to specified path.
+func (r *detector) fetchMetadata(ctx context.Context, ref string, desc ocispec.Descriptor, metadataPath string) error {
+	handle := func() error {
+		resolver := r.remote.Resolve(ctx, ref)
+		fetcher, err := resolver.Fetcher(ctx, ref)
+		if err != nil {
+			return errors.Wrap(err, "get fetcher")
+		}
+
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return errors.Wrap(err, "fetch nydus metadata")
+		}
+		defer rc.Close()
+
+		// Unpack nydus metadata file to specified path.
+		if err := remote.Unpack(rc, metadataNameInLayer, metadataPath); err != nil {
+			os.Remove(metadataPath)
+			return errors.Wrap(err, "unpack metadata from layer")
+		}
+
+		return nil
+	}
+
+	// Check if metafile already exists to avoid unnecessary fetch
+	if _, err := os.Stat(metadataPath); err == nil {
+		return nil
+	}
+
+	err := handle()
+	if err != nil && r.remote.RetryWithPlainHTTP(ref, err) {
+		return handle()
+	}
+
+	return err
+}

--- a/pkg/index/detector_test.go
+++ b/pkg/index/detector_test.go
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasNydusFeatures(t *testing.T) {
+	d := &detector{}
+
+	tests := []struct {
+		name     string
+		platform *ocispec.Platform
+		expected bool
+	}{
+		{
+			name:     "nil platform",
+			platform: nil,
+			expected: false,
+		},
+		{
+			name: "platform without os features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			},
+			expected: false,
+		},
+		{
+			name: "platform with nydus features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"nydus.remoteimage.v1"},
+			},
+			expected: true,
+		},
+		{
+			name: "platform with multiple features including nydus",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"feature1", "nydus.remoteimage.v1", "feature2"},
+			},
+			expected: true,
+		},
+		{
+			name: "platform with non-nydus features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"feature1", "feature2"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := d.hasNydusFeatures(tt.platform)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindNydusManifestInIndex(t *testing.T) {
+	d := &detector{}
+
+	manifestDigest := digest.FromString("test-manifest")
+	nydusManifestDigest := digest.FromString("nydus-manifest")
+
+	tests := []struct {
+		name           string
+		index          ocispec.Index
+		manifestDigest digest.Digest
+		expectedDigest *digest.Digest
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "original manifest not found in index",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "not found in index",
+		},
+		{
+			name: "no nydus alternative found",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: digest.FromString("other-manifest"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "no nydus alternative found",
+		},
+		{
+			name: "nydus alternative found",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectedDigest: &nydusManifestDigest,
+			expectError:    false,
+		},
+		{
+			name: "multiple nydus alternatives, returns first match",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+					{
+						Digest: digest.FromString("second-nydus-manifest"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectedDigest: &nydusManifestDigest,
+			expectError:    false,
+		},
+		{
+			name: "nydus alternative with different architecture ignored",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: digest.FromString("nydus-arm64"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "arm64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "no nydus alternative found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := d.findNydusManifestInIndex(tt.index, tt.manifestDigest)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, *tt.expectedDigest, result.Digest)
+			}
+		})
+	}
+}

--- a/pkg/index/manager.go
+++ b/pkg/index/manager.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/golang/groupcache/lru"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
+)
+
+type Manager struct {
+	insecure bool
+	cache    *lru.Cache
+	sg       singleflight.Group
+}
+
+func NewManager(insecure bool) *Manager {
+	manager := Manager{
+		insecure: insecure,
+		cache:    lru.New(500),
+		sg:       singleflight.Group{},
+	}
+
+	return &manager
+}
+
+// CheckIndexAlternative attempts to find a nydus alternative manifest
+// within an OCI index manifest for the specified manifest digest.
+func (manager *Manager) CheckIndexAlternative(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {
+	nydusDesc, err, _ := manager.sg.Do(manifestDigest.String(), func() (interface{}, error) {
+		// Try to get nydus metadata layer descriptor from LRU cache.
+		desc, ok := manager.cache.Get(manifestDigest)
+		if ok {
+			metaLayer, ok := desc.(ocispec.Descriptor)
+			if ok {
+				return &metaLayer, nil
+			}
+			return nil, errors.New("no alternative nydus descriptor found in cache")
+		}
+
+		keyChain, err := auth.GetKeyChainByRef(ref, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "get key chain")
+		}
+
+		// No LRU cache found, try to detect nydus alternative in index manifest.
+		detector := newDetector(keyChain, manager.insecure)
+		metaLayer, err := detector.checkIndexAlternative(ctx, ref, manifestDigest)
+		if err != nil {
+			// Cache empty result to avoid repeated failures.
+			// The index manifest can't change as it would change its digest so checking once is enough
+			manager.cache.Add(manifestDigest, nil)
+			return nil, errors.Wrap(err, "check index alternative")
+		}
+
+		// Cache the result for future use
+		manager.cache.Add(manifestDigest, *metaLayer)
+
+		return metaLayer, nil
+	})
+
+	if err != nil {
+		log.G(ctx).WithField("ref", ref).WithError(err).Warn("index detection failed")
+		return nil, err
+	}
+
+	return nydusDesc.(*ocispec.Descriptor), nil
+}
+
+// TryFetchMetadata try to fetch and unpack nydus metadata file to specified path.
+func (manager *Manager) TryFetchMetadata(ctx context.Context, ref string, manifestDigest digest.Digest, metadataPath string) error {
+	metaLayer, err := manager.CheckIndexAlternative(ctx, ref, manifestDigest)
+	if err != nil {
+		return errors.Wrap(err, "check index alternative")
+	}
+
+	keyChain, err := auth.GetKeyChainByRef(ref, nil)
+	if err != nil {
+		return errors.Wrap(err, "get key chain")
+	}
+
+	detector := newDetector(keyChain, manager.insecure)
+	return detector.fetchMetadata(ctx, ref, *metaLayer, metadataPath)
+}

--- a/pkg/index/manager_test.go
+++ b/pkg/index/manager_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIndexAlternative(t *testing.T) {
+	manifestDigest := digest.FromString("test-manifest")
+	ref := "registry.example.com/test/repo:latest"
+
+	expectedDesc := &ocispec.Descriptor{
+		Digest: digest.FromString("meta-layer"),
+	}
+
+	t.Run("cache hit, nydus present", func(t *testing.T) {
+		manager := NewManager(false)
+		manager.cache.Add(manifestDigest, *expectedDesc)
+
+		result, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDesc, result)
+	})
+
+	t.Run("cache hit, no nydus", func(t *testing.T) {
+		manager := NewManager(false)
+		manager.cache.Add(manifestDigest, nil)
+
+		_, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no alternative nydus descriptor found in cache")
+	})
+}

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -82,6 +82,9 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 		case label.IsNydusDataLayer(labels):
 			logger.Debugf("found nydus data layer")
 			handler = skipHandler
+		case sn.fs.CheckIndexAlternative(ctx, labels):
+			logger.Debugf("found nydus alternative image in index")
+			handler = skipHandler
 		case sn.fs.CheckReferrer(ctx, labels):
 			logger.Debugf("found referenced nydus manifest")
 			handler = skipHandler
@@ -137,6 +140,17 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 		if handler == nil {
 			if id, info, err := sn.findMetaLayer(ctx, key); err == nil {
 				logger.Infof("Prepare active Nydus snapshot %s", key)
+				handler = remoteHandler(id, info.Labels)
+			}
+		}
+
+		if handler == nil && sn.fs.IndexDetectEnabled() {
+			if id, info, err := sn.findIndexAlternativeLayer(ctx, key); err == nil {
+				logger.Infof("Found nydus alternative image in index for image: %s", info.Labels[snpkg.TargetRefLabel])
+				metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
+				if err := sn.fs.TryFetchMetadataFromIndex(ctx, info.Labels, metaPath); err != nil {
+					return nil, "", errors.Wrap(err, "try fetch metadata")
+				}
 				handler = remoteHandler(id, info.Labels)
 			}
 		}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/cgroup"
 	v2 "github.com/containerd/nydus-snapshotter/pkg/cgroup/v2"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/index"
 	mgr "github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
@@ -219,6 +220,11 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		return nil, errors.Wrap(err, "create cache manager")
 	}
 	opts = append(opts, filesystem.WithCacheManager(cacheMgr))
+
+	if cfg.Experimental.EnableIndexDetect {
+		indexMgr := index.NewManager(skipSSLVerify)
+		opts = append(opts, filesystem.WithIndexManager(indexMgr))
+	}
 
 	if cfg.Experimental.EnableReferrerDetect {
 		referrerMgr := referrer.NewManager(skipSSLVerify)
@@ -420,6 +426,13 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 		}
 	case snapshots.KindCommitted:
 	case snapshots.KindUnknown:
+	}
+
+	if o.fs.IndexDetectEnabled() && !needRemoteMounts {
+		if id, _, err := o.findIndexAlternativeLayer(ctx, key); err == nil {
+			needRemoteMounts = true
+			metaSnapshotID = id
+		}
 	}
 
 	if o.fs.ReferrerDetectEnabled() && !needRemoteMounts {
@@ -714,6 +727,12 @@ func (o *snapshotter) workPath(id string) string {
 	return filepath.Join(o.root, "snapshots", id, "work")
 }
 
+func (o *snapshotter) findIndexAlternativeLayer(ctx context.Context, key string) (string, snapshots.Info, error) {
+	return snapshot.IterateParentSnapshots(ctx, o.ms, key, func(_ string, i snapshots.Info) bool {
+		return o.fs.CheckIndexAlternative(ctx, i.Labels)
+	})
+}
+
 func (o *snapshotter) findReferrerLayer(ctx context.Context, key string) (string, snapshots.Info, error) {
 	return snapshot.IterateParentSnapshots(ctx, o.ms, key, func(_ string, info snapshots.Info) bool {
 		return o.fs.CheckReferrer(ctx, info.Labels)
@@ -905,7 +924,7 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	}
 
 	lowerPaths := make([]string, 0, 8)
-	if o.fs.ReferrerDetectEnabled() {
+	if o.fs.ReferrerDetectEnabled() || o.fs.IndexDetectEnabled() {
 		// From the parent list, we want to add all the layers
 		// between the upmost snapshot and the nydus meta snapshot.
 		// On the other hand, we consider that all the layers below

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -23,9 +23,9 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - ""
-    resources: 
+    resources:
     - nodes
     verbs:
     - get
@@ -233,6 +233,8 @@ data:
     [image]
     public_key_file = ""
     validate_signature = false
+    [experimental]
+    enable_index_detect = true
 
   nydusd.json: |-
     {

--- a/tests/helpers/kind.sh
+++ b/tests/helpers/kind.sh
@@ -2,6 +2,7 @@
 set -o errexit -o errtrace -o functrace -o nounset -o pipefail
 
 AUTH_TYPE="${AUTH_TYPE:-kubeconf}"
+INDEX_DETECT="${INDEX_DETECT:-false}"
 [ "$(uname -m)" == "aarch64" ] && GOARCH=arm64 || GOARCH=amd64
 ROOTFUL="${ROOTFUL:-}"
 
@@ -18,6 +19,11 @@ NYDUS_VERSION=v2.3.0
 DOCKER_USER=testuser
 DOCKER_PASSWORD=testpassword
 NAMESPACE=nydus-system
+
+ADDITIONAL_NYDUS_CONVERT_ARGS=""
+if [ "$INDEX_DETECT" == "true" ]; then
+  ADDITIONAL_NYDUS_CONVERT_ARGS="--merge-platform"
+fi
 
 log::info "Configuring rootful and github"
 configure::rootful "${ROOTFUL:-}"
@@ -68,7 +74,8 @@ log::info "Converting test image to nydus and push"
 exec::nydusify convert \
    --source busybox:latest \
    --target $registry_url/busybox:nydus-v6-latest \
-   --fs-version 6
+   --fs-version 6 \
+   ${ADDITIONAL_NYDUS_CONVERT_ARGS}
 
 # Create fresh cluster
 log::info "Creating new cluster"
@@ -109,5 +116,14 @@ exec::kubectl wait po test-pod --namespace nydus-system --for=condition=ready --
   exec::kubectl --namespace nydus-system logs test-pod
   exit 1
 }
-exec::kubectl delete -f tests/e2e/k8s/test-pod.yaml
 
+if [ "$INDEX_DETECT" == "true" ]; then
+  snapshotter_logs="$(exec::kubectl --namespace nydus-system exec nydus-snapshotter -- cat /var/lib/containerd/io.containerd.snapshotter.v1.nydus/logs/nydus-snapshotter.log)"
+  echo "$snapshotter_logs" | grep -q "Found nydus alternative image in index for image" || {
+    echo "Nydus snapshotter did not detect nydus image in index. Logs:"
+    echo "$snapshotter_logs"
+    exit 1
+  }
+fi
+
+exec::kubectl delete -f tests/e2e/k8s/test-pod.yaml


### PR DESCRIPTION
Implement index detection feature that automatically discovers Nydus alternative manifests within OCI index manifests, similar to what SOCI snashotter is able to do. This enables transparent fallback to optimized Nydus images when available while keeping the original index manifest OCI compliant as non-nydus client can simply pull the regular OCI image.

The feature is heavily based on the already existing ReferrerDetect feature which looks for nydus manifests using the referrer API. However, the referrer API is not supported by all registries and as it relies on changes happening outside the manifest being pulled it's a bit dangerous from a supply chain perspective. On the other hand, this new IndexDetect feature is supported everywhere and does not have the supply chain issue as everyting is packed in a single manifest. Building a manifest compatible with this feature is can be easily done with the `--merge-platform` flag in `nydusify convert`.

Key changes:
- Add EnableIndexDetect config option to experimental features                                                                                                       - Implement index package with manifest finding logic. Very similar to [referrer package](https://github.com/DataDog/nydus-snapshotter/blob/main/pkg/referrer/referrer.go). The detection is based on the platform.os.feature field in the index manifest which must be `nydus.remoteimage.v1`
- Result is cached to avoid multiple API calls for the same digest
- Integrate index detection into filesystem and snapshot layers. The index detection is done before the referrer detection: if both exist, we prefer to use the index detection for the supply chain issues mentionned above.

Note: I did not attempt to refactor the existing referrerDetect code despite both feature sharing similar code. That's mainly to avoid needless merge conflicts with our fork. I'm open to try refactoring this if we need this to integrate upstream.

e2e test: https://github.com/DataDog/nydus-snapshotter/actions/runs/17100323777/job/48494830927?pr=3