### PR TITLE
[index] Reduce logging when we hit empty cache for subsequent layers

### DIFF
--- a/pkg/index/manager.go
+++ b/pkg/index/manager.go
@@ -45,7 +45,7 @@ func (manager *Manager) CheckIndexAlternative(ctx context.Context, ref string, m
 			if ok {
 				return &metaLayer, nil
 			}
-			return nil, errors.New("no alternative nydus descriptor found in cache")
+			return nil, nil
 		}
 
 		keyChain, err := auth.GetKeyChainByRef(ref, nil)
@@ -69,8 +69,14 @@ func (manager *Manager) CheckIndexAlternative(ctx context.Context, ref string, m
 		return metaLayer, nil
 	})
 
+	logger := log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String())
 	if err != nil {
-		log.G(ctx).WithField("ref", ref).WithError(err).Warn("index detection failed")
+		logger.WithError(err).Warn("index detection failed")
+		return nil, err
+	}
+	if nydusDesc == nil {
+		err = errors.New("no alternative nydus descriptor found in index")
+		logger.WithError(err).Debug("nil nydus descriptor")
 		return nil, err
 	}
 

--- a/pkg/index/manager_test.go
+++ b/pkg/index/manager_test.go
@@ -40,6 +40,6 @@ func TestCheckIndexAlternative(t *testing.T) {
 		_, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
 
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no alternative nydus descriptor found in cache")
+		assert.Contains(t, err.Error(), "no alternative nydus descriptor found in index")
 	})
 }


### PR DESCRIPTION
There is no need to repeat the same Warn log #layers times once we have checked that there is no index alternative. Instead we should catch the case where the returned nydus descriptor is nil and log using debug only.

Instead of logging `"no alternative nydus descriptor found in cache"` for each layer, we will log `"check index alternative: no nydus alternative found in index for ..."` just once on the first layer.