### PR TITLE
[index] Improve detection logic with persistent caching

### DIFF
--- a/pkg/filesystem/index_adaptor.go
+++ b/pkg/filesystem/index_adaptor.go
@@ -9,9 +9,11 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"os"
 
 	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -36,10 +38,20 @@ func (fs *Filesystem) CheckIndexAlternative(ctx context.Context, labels map[stri
 		return false
 	}
 
-	log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String()).Debug("attempting index-based nydus detection")
+	logger := log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String())
+	logger.Debug("attempting index-based nydus detection")
+
+	// Early exit if the labels explicitly indicates the presence of a nydus index alternative
+	hasIndexAlternative, ok := labels[label.NydusIndexAlternative]
+	if ok && hasIndexAlternative == "true" {
+		logger.Debug("detected nydus alternative via label")
+		return true
+	}
+
 	if _, err := fs.indexMgr.CheckIndexAlternative(ctx, ref, manifestDigest); err != nil {
 		return false
 	}
+	logger.Debug("detected nydus alternative via index manifest")
 
 	return true
 }
@@ -54,6 +66,12 @@ func (fs *Filesystem) TryFetchMetadataFromIndex(ctx context.Context, labels map[
 	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
 	if err := manifestDigest.Validate(); err != nil {
 		return fmt.Errorf("invalid label %s=%s", snpkg.TargetManifestDigestLabel, manifestDigest)
+	}
+
+	// Early exit if the file already exists
+	if _, err := os.Stat(metadataPath); err == nil {
+		log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String()).WithField("metadataPath", metadataPath).Debugf("metadata file already exists")
+		return nil
 	}
 
 	if err := fs.indexMgr.TryFetchMetadata(ctx, ref, manifestDigest, metadataPath); err != nil {

--- a/pkg/filesystem/index_adaptor.go
+++ b/pkg/filesystem/index_adaptor.go
@@ -41,7 +41,7 @@ func (fs *Filesystem) CheckIndexAlternative(ctx context.Context, labels map[stri
 	logger := log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String())
 	logger.Debug("attempting index-based nydus detection")
 
-	// Early exit if the labels explicitly indicates the presence of a nydus index alternative
+	// Early exit if the labels explicitly indicate the presence of a nydus index alternative
 	hasIndexAlternative, ok := labels[label.NydusIndexAlternative]
 	if ok && hasIndexAlternative == "true" {
 		logger.Debug("detected nydus alternative via label")

--- a/pkg/index/detector.go
+++ b/pkg/index/detector.go
@@ -178,11 +178,6 @@ func (r *detector) fetchMetadata(ctx context.Context, ref string, desc ocispec.D
 		return nil
 	}
 
-	// Check if metafile already exists to avoid unnecessary fetch
-	if _, err := os.Stat(metadataPath); err == nil {
-		return nil
-	}
-
 	err := handle()
 	if err != nil && r.remote.RetryWithPlainHTTP(ref, err) {
 		return handle()

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -60,6 +60,9 @@ const (
 	// A bool flag to mark it is recommended to run this image with tarfs mode, set by image builders.
 	// runtime can decide whether to rely on this annotation
 	TarfsHint = "containerd.io/snapshot/tarfs-hint"
+
+	// An alternative nydus index manifest exists in the original OCI index manifest for this snapshot
+	NydusIndexAlternative = "containerd.io/snapshot/nydus-index-alternative"
 )
 
 func IsNydusDataLayer(labels map[string]string) bool {

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -25,8 +25,9 @@ import (
 // Different actions for different layer types
 func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 	sn *snapshotter, s storage.Snapshot, key, parent string, labels map[string]string,
-	storageLocater func() string) (_ func() (bool, []mount.Mount, error), target string, err error) {
+	storageLocater func() string) (_ func() (bool, []mount.Mount, error), target string, commitLabels map[string]string, err error) {
 	var handler func() (bool, []mount.Mount, error)
+	commitLabels = labels
 
 	// Handler to prepare a directory for containerd to download and unpacking layer.
 	defaultHandler := func() (bool, []mount.Mount, error) {
@@ -74,7 +75,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 				labels[label.NydusProxyMode] = "true"
 				handler = skipHandler
 			} else {
-				return nil, "", errors.Errorf("missing CRI reference annotation for snapshot %s", s.ID)
+				return nil, "", nil, errors.Errorf("missing CRI reference annotation for snapshot %s", s.ID)
 			}
 		case label.IsNydusMetaLayer(labels):
 			logger.Debugf("found nydus meta layer")
@@ -84,6 +85,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			handler = skipHandler
 		case sn.fs.CheckIndexAlternative(ctx, labels):
 			logger.Debugf("found nydus alternative image in index")
+			commitLabels[label.NydusIndexAlternative] = "true"
 			handler = skipHandler
 		case sn.fs.CheckReferrer(ctx, labels):
 			logger.Debugf("found referenced nydus manifest")
@@ -114,7 +116,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 					if config.GetTarfsExportEnabled() {
 						_, err = sn.fs.ExportBlockData(s, true, labels, func(id string) string { return sn.upperPath(id) })
 						if err != nil {
-							return nil, "", errors.Wrap(err, "export layer as tarfs block device")
+							return nil, "", nil, errors.Wrap(err, "export layer as tarfs block device")
 						}
 					}
 					handler = skipHandler
@@ -149,7 +151,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 				logger.Infof("Found nydus alternative image in index for image: %s", info.Labels[snpkg.TargetRefLabel])
 				metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
 				if err := sn.fs.TryFetchMetadataFromIndex(ctx, info.Labels, metaPath); err != nil {
-					return nil, "", errors.Wrap(err, "try fetch metadata")
+					return nil, "", nil, errors.Wrap(err, "try fetch metadata")
 				}
 				handler = remoteHandler(id, info.Labels)
 			}
@@ -160,7 +162,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 				logger.Infof("Found referenced nydus manifest for image: %s", info.Labels[snpkg.TargetRefLabel])
 				metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
 				if err := sn.fs.TryFetchMetadata(ctx, info.Labels, metaPath); err != nil {
-					return nil, "", errors.Wrap(err, "try fetch metadata")
+					return nil, "", nil, errors.Wrap(err, "try fetch metadata")
 				}
 				handler = remoteHandler(id, info.Labels)
 			}
@@ -168,7 +170,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 
 		if handler == nil && pErr == nil && sn.fs.StargzEnabled() && sn.fs.StargzLayer(pInfo.Labels) {
 			if err := sn.fs.MergeStargzMetaLayer(ctx, s); err != nil {
-				return nil, "", errors.Wrap(err, "merge stargz meta layers")
+				return nil, "", nil, errors.Wrap(err, "merge stargz meta layers")
 			}
 			handler = remoteHandler(pID, pInfo.Labels)
 			logger.Infof("Generated estargz merged meta for %s", key)
@@ -182,7 +184,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			logger.Infof("Prepare active snapshot %s in Nydus tarfs mode", key)
 			err = sn.mergeTarfs(ctx, s, pID, pInfo)
 			if err != nil {
-				return nil, "", errors.Wrapf(err, "merge tarfs layers for snapshot %s", pID)
+				return nil, "", nil, errors.Wrapf(err, "merge tarfs layers for snapshot %s", pID)
 			}
 			logger.Infof("Prepared active snapshot %s in Nydus tarfs mode", key)
 			handler = remoteHandler(pID, pInfo.Labels)
@@ -193,5 +195,5 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 		handler = defaultHandler
 	}
 
-	return handler, target, err
+	return handler, target, commitLabels, err
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -475,7 +475,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 	logger.Debugf("[Prepare] snapshot with labels %v", info.Labels)
 
-	processor, target, err := chooseProcessor(ctx, logger, o, s, key, parent, info.Labels, func() string { return o.upperPath(s.ID) })
+	processor, target, commitLabels, err := chooseProcessor(ctx, logger, o, s, key, parent, info.Labels, func() string { return o.upperPath(s.ID) })
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	needCommit, mounts, err := processor()
 
 	if needCommit {
-		err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(info.Labels))...)
+		err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(commitLabels))...)
 		if err == nil || errdefs.IsAlreadyExists(err) {
 			return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
 		}


### PR DESCRIPTION
The previous index detection logic had an issue where if the snaphotter was restarted, it would then lose all its cached credentials and could end up in a situation where it cant't fetch the index manifest and won't be able to determine if an image has an index alternative anymore. A troublesome situation because nyduse will then try to mount the snapshots in `native` mode which will result in an overlay mount that only contains the image.boot and not the actual fs. To solve this, the information on whether a snapshot has a nydus alternative will be stored inside the content store directly under a new label `containerd.io/snapshot/nydus-index-alternative`. Additionally, the `TryFetchMetadataFromIndex` has been modified to return early if the metadata file already exists on the filesystem. This way, we avoid all registry api calls once they have been done a first time since all the needed information becomes stored on the filesystem.