### PR TITLE
[snasphot] Bind mount parent in single parent mount case

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -990,7 +990,10 @@ func (o *snapshotter) mountNative(ctx context.Context, labels map[string]string,
 			options = append(options, "volatile")
 		}
 	} else if len(s.ParentIDs) == 1 {
-		return bindMount(o.upperPath(s.ID), "ro"), nil
+		parentPath := o.upperPath(s.ParentIDs[0])
+		// if we only have one parent then just return a bind mount
+		log.G(ctx).Debugf("bind mount on %s", parentPath)
+		return bindMount(parentPath, "ro"), nil
 	}
 
 	parentPaths := make([]string, len(s.ParentIDs))


### PR DESCRIPTION
The code was creating a bind mount of the new snapshot (which is empty) instead of doing a bind on the parent snasphot (with content)