### PR TITLE
[Cleanup] Add unused cache blob garbage collection

### DIFF
--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -119,4 +120,33 @@ func (m *Manager) RemoveBlobCache(blobID string) error {
 		}
 	}
 	return nil
+}
+
+// extractBlobIDFromFilename extracts the blob ID from a cache filename
+// Cache files can have formats like:
+// - <blobID>
+// - <blobID>.blob.data
+// - <blobID>.chunk_map
+// - <blobID>.blob.meta
+// - <blobID>.image.disk
+// - <blobID>.layer.disk
+func ExtractBlobIDFromFilename(filename string) string {
+	// Remove known suffixes
+	suffixes := []string{
+		dataFileSuffix,
+		dataFileSuffix + chunkMapFileSuffix,
+		chunkMapFileSuffix,
+		metaFileSuffix,
+		imageDiskFileSuffix,
+		layerDiskFileSuffix,
+	}
+
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(filename, suffix) {
+			return strings.TrimSuffix(filename, suffix)
+		}
+	}
+
+	// If no suffix matches, assume it's already a blob ID
+	return filename
 }

--- a/pkg/cache/manager_test.go
+++ b/pkg/cache/manager_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBlobIDFromFilename(t *testing.T) {
+	tests := map[string]struct {
+		filename string
+		expected string
+	}{
+		"plain blob ID": {
+			filename: "abc123def456",
+			expected: "abc123def456",
+		},
+		"blob with .blob.data suffix": {
+			filename: "abc123def456.blob.data",
+			expected: "abc123def456",
+		},
+		"blob with .chunk_map suffix": {
+			filename: "abc123def456.chunk_map",
+			expected: "abc123def456",
+		},
+		"blob with .blob.meta suffix": {
+			filename: "abc123def456.blob.meta",
+			expected: "abc123def456",
+		},
+		"blob with .image.disk suffix": {
+			filename: "abc123def456.image.disk",
+			expected: "abc123def456",
+		},
+		"blob with .layer.disk suffix": {
+			filename: "abc123def456.layer.disk",
+			expected: "abc123def456",
+		},
+		"blob with combined .blob.data.chunk_map suffix": {
+			filename: "abc123def456.blob.data.chunk_map",
+			expected: "abc123def456",
+		},
+		"real sha256 hash": {
+			filename: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		"real sha256 hash with .blob.data": {
+			filename: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.blob.data",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		"real sha256 hash with .chunk_map": {
+			filename: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.chunk_map",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		"real sha256 hash with .blob.data.chunk_map": {
+			filename: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.blob.data.chunk_map",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		"empty filename": {
+			filename: "",
+			expected: "",
+		},
+		"filename with unknown suffix": {
+			filename: "abc123def456.unknown",
+			expected: "abc123def456.unknown",
+		},
+		"filename with multiple dots but no known suffix": {
+			filename: "abc.def.ghi",
+			expected: "abc.def.ghi",
+		},
+		".blob.data.chunk_map is matched before .blob.data or .chunk_map": {
+			filename: "test.blob.data.chunk_map",
+			expected: "test",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := ExtractBlobIDFromFilename(tc.filename)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -151,6 +151,10 @@ func (d *Daemon) AddRafsInstance(r *rafs.Rafs) {
 	r.DaemonID = d.ID()
 }
 
+func (d *Daemon) UpdateRafsInstance(r *rafs.Rafs) {
+	d.RafsCache.Add(r)
+}
+
 func (d *Daemon) RemoveRafsInstance(snapshotID string) {
 	d.RafsCache.Remove(snapshotID)
 	d.DecRef()

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -262,6 +262,24 @@ func (fs *Filesystem) WaitUntilReady(snapshotID string) error {
 			return err
 		}
 
+		var sid string
+		if d.IsSharedDaemon() {
+			sid = rafs.SnapshotID
+		} else {
+			sid = ""
+		}
+
+		cacheMetrics, err := d.GetCacheMetrics(sid)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get cache metric")
+		}
+		log.L.Debugf("Found %d underlying files for rafs instance %s", len(cacheMetrics.UnderlyingFiles), rafs.SnapshotID)
+		rafs.UnderlyingFiles = cacheMetrics.UnderlyingFiles
+		fsManager, err := fs.getManager(rafs.GetFsDriver())
+		if err != nil {
+			return err
+		}
+		fsManager.UpdateRafsInstance(rafs)
 		log.L.Debugf("Nydus remote snapshot %s is ready", snapshotID)
 	}
 
@@ -582,6 +600,24 @@ func (fs *Filesystem) RemoveCache(blobDigest string) error {
 	}
 
 	return fs.cacheMgr.RemoveBlobCache(blobID)
+}
+
+// WalkManagers iterates over all enabled managers and calls the provided function
+func (fs *Filesystem) WalkManagers(fn func(*manager.Manager) error) error {
+	for _, mgr := range fs.enabledManagers {
+		if err := fn(mgr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetCacheConfig returns the cache directory from the cache manager
+func (fs *Filesystem) GetCacheDir() (string, error) {
+	if fs.cacheMgr == nil {
+		return "", errors.New("cache manager is not initialized")
+	}
+	return fs.cacheMgr.CacheDir(), nil
 }
 
 // Try to stop all the running daemons if they are not referenced by any snapshots

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -146,6 +146,10 @@ func (m *Manager) AddRafsInstance(r *rafs.Rafs) error {
 	return m.store.AddRafsInstance(r)
 }
 
+func (m *Manager) UpdateRafsInstance(r *rafs.Rafs) error {
+	return m.store.UpdateRafsInstance(r)
+}
+
 func (m *Manager) RemoveRafsInstance(snapshotID string) error {
 	return m.store.DeleteRafsInstance(snapshotID)
 }

--- a/pkg/manager/store.go
+++ b/pkg/manager/store.go
@@ -25,6 +25,7 @@ type Store interface {
 	CleanupDaemons(ctx context.Context) error
 
 	AddRafsInstance(r *rafs.Rafs) error
+	UpdateRafsInstance(r *rafs.Rafs) error
 	DeleteRafsInstance(snapshotID string) error
 	WalkRafsInstances(ctx context.Context, cb func(*rafs.Rafs) error) error
 

--- a/pkg/metrics/data/snapshotter.go
+++ b/pkg/metrics/data/snapshotter.go
@@ -80,4 +80,25 @@ var (
 			Help: "Thread counts of snapshotter.",
 		},
 	)
+
+	CacheBlobsDeleted = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "snapshotter_cache_blobs_deleted_total",
+			Help: "Total number of cache blobs deleted during cleanup.",
+		},
+	)
+
+	CacheBlobsInUse = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "snapshotter_cache_blobs_in_use",
+			Help: "Number of cache blobs currently in use by running daemons.",
+		},
+	)
+
+	CacheBlobDeletionErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "snapshotter_cache_blob_deletion_errors_total",
+			Help: "Total number of errors encountered while deleting cache blobs.",
+		},
+	)
 )

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -33,6 +33,9 @@ func init() {
 		data.Fds,
 		data.RunTime,
 		data.Thread,
+		data.CacheBlobsDeleted,
+		data.CacheBlobsInUse,
+		data.CacheBlobDeletionErrors,
 	)
 
 	for _, m := range data.MetricHists {

--- a/pkg/rafs/rafs.go
+++ b/pkg/rafs/rafs.go
@@ -110,12 +110,13 @@ func (rs *Cache) SetIntances(instances map[string]*Rafs) {
 
 // The whole struct will be persisted
 type Rafs struct {
-	Seq         uint64
-	ImageID     string // Usually is the image reference
-	DaemonID    string
-	FsDriver    string
-	SnapshotID  string // Given by containerd
-	SnapshotDir string
+	Seq             uint64
+	ImageID         string // Usually is the image reference
+	DaemonID        string
+	FsDriver        string
+	SnapshotID      string // Given by containerd
+	SnapshotDir     string
+	UnderlyingFiles []string // Underlying cache blob files
 	// 1. A host kernel EROFS/TARFS mountpoint
 	// 2. Absolute path to each rafs instance root directory.
 	Mountpoint  string
@@ -125,11 +126,12 @@ type Rafs struct {
 func NewRafs(snapshotID, imageID, fsDriver string) (*Rafs, error) {
 	snapshotDir := path.Join(config.GetSnapshotsRootDir(), snapshotID)
 	rafs := &Rafs{
-		FsDriver:    fsDriver,
-		ImageID:     imageID,
-		SnapshotID:  snapshotID,
-		SnapshotDir: snapshotDir,
-		Annotations: make(map[string]string),
+		FsDriver:        fsDriver,
+		ImageID:         imageID,
+		SnapshotID:      snapshotID,
+		SnapshotDir:     snapshotDir,
+		Annotations:     make(map[string]string),
+		UnderlyingFiles: []string{},
 	}
 
 	if err := os.MkdirAll(snapshotDir, 0755); err != nil {

--- a/pkg/store/daemonstore.go
+++ b/pkg/store/daemonstore.go
@@ -51,6 +51,10 @@ func (s *DaemonRafsStore) AddRafsInstance(r *rafs.Rafs) error {
 	return s.db.AddRafsInstance(context.TODO(), r)
 }
 
+func (s *DaemonRafsStore) UpdateRafsInstance(r *rafs.Rafs) error {
+	return s.db.UpdateRafsInstance(context.TODO(), r)
+}
+
 func (s *DaemonRafsStore) DeleteRafsInstance(snapshotID string) error {
 	return s.db.DeleteRafsInstance(context.TODO(), snapshotID)
 }

--- a/pkg/store/database.go
+++ b/pkg/store/database.go
@@ -287,6 +287,14 @@ func (db *Database) AddRafsInstance(_ context.Context, instance *rafs.Rafs) erro
 	})
 }
 
+func (db *Database) UpdateRafsInstance(_ context.Context, instance *rafs.Rafs) error {
+	return db.db.Update(func(tx *bolt.Tx) error {
+		bucket := getInstancesBucket(tx)
+
+		return updateObject(bucket, instance.SnapshotID, instance)
+	})
+}
+
 func (db *Database) DeleteRafsInstance(_ context.Context, snapshotID string) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getInstancesBucket(tx)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -34,6 +34,7 @@ import (
 	mgr "github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
+	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
 	"github.com/containerd/nydus-snapshotter/pkg/pprof"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/system"
@@ -322,6 +323,23 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 			log.L.WithError(err).Warnf("failed to remove directory %s", dir)
 		}
 	}
+
+	cleanup, err = o.cleanupUnusedCacheBlobs(ctx)
+	if err != nil {
+		return err
+	}
+	log.L.Infof("[Cleanup] unused cache blobs %v", cleanup)
+
+	for _, blob := range cleanup {
+		// Add sha256: prefix to make it a valid blob digest
+		if err := o.fs.RemoveCache("sha256:" + blob); err != nil {
+			log.L.WithError(err).Warnf("failed to remove cache blob %s", blob)
+			data.CacheBlobDeletionErrors.Inc()
+		} else {
+			data.CacheBlobsDeleted.Inc()
+		}
+	}
+
 	return nil
 }
 
@@ -1092,6 +1110,85 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	}
 
 	return nil
+}
+
+func (o *snapshotter) cleanupUnusedCacheBlobs(ctx context.Context) ([]string, error) {
+	// Get a write transaction to ensure no other write transaction can be entered
+	// while the cleanup is scanning.
+	_, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err := t.Rollback(); err != nil {
+			log.L.WithError(err)
+		}
+	}()
+
+	// Collect all used blob IDs from all daemons
+	usedBlobIDs := make(map[string]bool)
+	if err := o.fs.WalkManagers(func(mgr *mgr.Manager) error {
+		for _, d := range mgr.ListDaemons() {
+			// Get all rafs instances for this daemon
+			for _, rafs := range d.RafsCache.List() {
+				// Extract blob IDs from underlying files and mark as used
+				for _, filePath := range rafs.UnderlyingFiles {
+					// Extract blob ID from the file path
+					filename := filepath.Base(filePath)
+					blobID := cache.ExtractBlobIDFromFilename(filename)
+					if blobID != "" {
+						usedBlobIDs[blobID] = true
+					}
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "walk managers to collect used blobs")
+	}
+
+	log.L.Debugf("[cleanupUnusedCacheBlobs] found %d used blob IDs", len(usedBlobIDs))
+
+	// Update metrics for blobs in use
+	data.CacheBlobsInUse.Set(float64(len(usedBlobIDs)))
+
+	cacheDir, err := o.fs.GetCacheDir()
+	if err != nil {
+		return nil, errors.Wrap(err, "get cache directory")
+	}
+
+	// List all files in cache directory
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read cache directory %s", cacheDir)
+	}
+
+	// Track which blob IDs we've already processed to avoid duplicate RemoveCache calls
+	storedBlobIDs := map[string]interface{}{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		blobID := cache.ExtractBlobIDFromFilename(entry.Name())
+		if blobID == "" {
+			log.L.Debugf("[cleanupUnusedCacheBlobs] skipping file with unknown format: %s", entry.Name())
+			continue
+		}
+
+		storedBlobIDs[blobID] = nil
+	}
+	log.L.Debugf("[cleanupUnusedCacheBlobs] found %d stored blob IDs", len(storedBlobIDs))
+
+	var unusedBlobIDs []string
+	for blobID := range storedBlobIDs {
+		if _, ok := usedBlobIDs[blobID]; !ok {
+			unusedBlobIDs = append(unusedBlobIDs, blobID)
+		}
+	}
+
+	return unusedBlobIDs, nil
 }
 
 func (o *snapshotter) snapshotRoot() string {


### PR DESCRIPTION
Implement automatic cleanup of unused cache blobs during snapshotter cleanup operations. This prevents cache directory leak by removing blob files that are no longer referenced by any active nydusd instances.

This should address https://github.com/containerd/nydus-snapshotter/issues/687

There are 2 steps to the cleaning process:
1. when nydusd starts and the snapshotter is waiting for it to be ready, once nydusd is running, the snapshotter will query its cache endpoint to get all the underlying files used by the RAFS instance. This information is then stored in the rafs in-memory cache and persisted in the nydus boltdb. This operation takes ~5ms due to needing to make an api call + modify the db. This will ensure that a snapshotter restart doesn't lose this information.
2. when the snapshotter Cleanup method is called, we iterate over all the running RAFS to list all the currently in-use files. Followed by a listing of all the files present in the cache directory. The files present in the cache but not in-use will be removed. This operation took <1ms in my tests but will grow with the amount of files in the cache directory. Though, the Cleanup method is here exactly for the use case of running potentially long cleanup operations so it's ok if it takes a bit longer

Added some metrics to measure cache usage as well

To help understand the problem and solution, here are 2 diagrams which mostly illustrate what's going on:
For the usual case of a Nydus image:
```mermaid
  sequenceDiagram
      participant Reg as Registry<br/>┌─ Nydus Image sha256:abc123<br/>└─ Layer sha256:80bfbb8a
      participant C as Containerd
      participant NS as Nydus Snapshotter
      participant Nydusd as nydusd
      participant Cache as Cache Directory
      participant Disk as Containerd State

      Note over Reg,Disk: Normal Nydus Image Pull
      C->>NS: Prepare layer sha256:80bfbb8a...
      NS->>Reg: Is nydus?
      Reg-->>NS: yes
      NS-->>C: Remote mount
      C->>Disk: Track layer sha256:80bfbb8a...
      C->>NS: Mount layer sha256:80bfbb8a...
      NS->>Nydusd: Start Nydusd
      Nydusd->>Reg: Download Nydus blob<br/>sha256:80bfbb8a...
      Reg-->>Nydusd: Nydus blob data
      Nydusd->>Cache: Store blob<br/>sha256:80bfbb8a...
      Cache-->>Nydusd: Blob stored
      Nydusd-->>NS: Nydusd ready
      NS-->>C: Mount ready
      Note over Cache,Disk: ✓ State matches:<br/>Cache has sha256:80bfbb8a<br/>Containerd tracks sha256:80bfbb8a

      Note over Reg,Disk: Container Removed - Cleanup
      C->>NS: Remove layer sha256:80bfbb8a...
      NS->>Cache: Delete blob sha256:80bfbb8a...
      Cache-->>NS: ✓ File found & deleted
      NS-->>C: Removed
      C->>Disk: Remove tracking sha256:80bfbb8a...
      Note over Cache,Disk: ✓ Successful cleanup<br/>Cache empty<br/>No tracking
```

For the problematic case with index detection and the solution:

```mermaid
  sequenceDiagram
      participant Reg as Registry<br/>┌─ Nydus Image with index-detect sha256:abc123<br/>├─ OCI Layer sha256:80bfbb8a<br/>└─ Nydus Layer sha256:0713669e
      participant C as Containerd
      participant NS as Nydus Snapshotter
      participant Nydusd as nydusd
      participant Cache as Cache Directory
      participant Disk as Containerd State

      Note over Reg,Disk: Image Pull with Index Detection
      C->>NS: Prepare OCI layer sha256:80bfbb8a...
      NS->>Reg: Query index<br/>for sha256:80bfbb8a...
      Reg-->>NS: Index manifest sha256:abc123...
      NS->>NS: Found Nydus alternative!<br/>sha256:0713669e...
      NS-->>C: Remote mount
      C->>Disk: Track OCI layer sha256:80bfbb8a...
      C->>NS: Mount layer sha256:80bfbb8a...
      NS->>Nydusd: Start nydusd
      Nydusd->>Reg: Download Nydus blob<br/>sha256:0713669e...
      Reg-->>Nydusd: Nydus blob data
      Nydusd->>Cache: Store blob<br/>sha256:0713669e...
      Cache-->>Nydusd: Blob stored
      Nydusd-->>NS: Nydusd ready
      NS-->>C: Mount ready
      Note over Cache,Disk: ⚠️ State mismatch:<br/>Cache has sha256:0713669e (Nydus)<br/>Containerd tracks sha256:80bfbb8a (OCI)

      Note over Reg,Disk: Container Removed - Cleanup Attempt
      C->>NS: Remove layer sha256:80bfbb8a...
      NS->>Cache: Delete blob sha256:80bfbb8a...
      Cache-->>NS: ✗ File not found!<br/>Only sha256:0713669e exists
      NS-->>C: Removed
      C->>Disk: Remove tracking sha256:80bfbb8a...
      Note over Cache,Disk: ✗ Cache leak!<br/>Cache has sha256:0713669e (orphaned)<br/>No tracking for this blob

      Note over Reg,Disk: Solution: GC During Snapshotter Cleanup
      C->>NS: Cleanup
      NS->>Nydusd: Query files in-use for active RAFS instances
      Nydusd-->>NS: In-use blobs:<br/>[sha256:aabbccff, ...]
      NS->>Cache: List all cache blobs
      Cache-->>NS: All blobs:<br/>[sha256:0713669e, sha256:aabbccff, ...]
      NS->>NS: Compare: cache vs in-use<br/>Find orphans
      NS->>Cache: Delete orphaned blobs [sha256:0713669e]
      Cache-->>NS: ✓ Orphaned blobs removed
      Note over Cache,Disk: ✓ Cache cleaned<br/>No orphans
```

## Test

Was tested locally using an index-detect image.
The cache files used to leak while now we can see that they are properly cleaned up:
```
DEBU[2025-12-05T17:43:42.736790365+01:00] [Cleanup] snapshots
INFO[2025-12-05T17:43:42.736866966+01:00] [Cleanup] orphan directories [/containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/89 /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/90]
DEBU[2025-12-05T17:43:42.736876932+01:00] no RAFS filesystem instance associated with snapshot 89
INFO[2025-12-05T17:43:42.741153287+01:00] Destroy nydusd daemon d4pgj4pjjoqfk878ge2g. Host mountpoint /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/90/mnt
INFO[2025-12-05T17:43:42.757568156+01:00] Deleting resources [/containerd-local/io.containerd.snapshotter.v1.nydus/config/d4pgj4pjjoqfk878ge2g /containerd-local/io.containerd.snapshotter.v1.nydus/logs/d4pgj4pjjoqfk878ge2g /containerd-local/io.containerd.snapshotter.v1.nydus/socket/d4pgj4pjjoqfk878ge2g]
DEBU[2025-12-05T17:43:42.757710416+01:00] [cleanupUnusedCacheBlobs] found 0 used blob IDs
DEBU[2025-12-05T17:43:42.757734174+01:00] [cleanupUnusedCacheBlobs] found 1 stored blob IDs
INFO[2025-12-05T17:43:42.757741106+01:00] [Cleanup] unused cache blobs [0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f]
INFO[2025-12-05T17:43:42.757750627+01:00] remove cache sha256:0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f
DEBU[2025-12-05T17:43:42.757772881+01:00] file /containerd-local/io.containerd.snapshotter.v1.nydus/cache/0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f.chunk_map doest not exist.
DEBU[2025-12-05T17:43:42.757818030+01:00] file /containerd-local/io.containerd.snapshotter.v1.nydus/cache/0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f doest not exist.
DEBU[2025-12-05T17:43:42.757956083+01:00] file /containerd-local/io.containerd.snapshotter.v1.nydus/cache/0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f.image.disk doest not exist.
DEBU[2025-12-05T17:43:42.757965258+01:00] file /containerd-local/io.containerd.snapshotter.v1.nydus/cache/0713669e321a795f8175192c6866928021e6a9ce832559d3315e35581dab340f.layer.disk doest not exist.
```
