### PR TITLE
[snapshot] Never remove cache during Remove operation

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -653,15 +653,6 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		log.L.Infof("[Remove] snapshot with key %s snapshot id %s", key, id)
 	}
 
-	if info.Kind == snapshots.KindCommitted {
-		blobDigest := info.Labels[snpkg.TargetLayerDigestLabel]
-		go func() {
-			if err := o.fs.RemoveCache(blobDigest); err != nil {
-				log.L.WithError(err).Errorf("Failed to remove cache %s", blobDigest)
-			}
-		}()
-	}
-
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to remove key %s", key)


### PR DESCRIPTION
There is a structural issue whith cache removal when it occurs during containerd's Remove call. There's an inherent mismatch between containerd layers representation and nydusd's. Containerd stores layers under a computed key called the ChainID where each ID depends on its parents. This help containerd ensure that 2 snapshots sharing the same key will always have the same parent. On the other hand, nydusd stores each layer on disk under its layer digest directly (the same one you can see in the image manifest). This allows nydusd to reuse same blobs when used in different images.

However, this creates a rift between both systems because if we have 2 images which have the same layers but in different order (layerA+layerB for image1 and layerB+layerA for image2), then those will be completely separate images for containerd because their chainID won't match but they will be backed by the same blobs on disk. As a result, if containerd has to remove image1, it won't consider its layers as in-use by an other image  and will Remove them. Thus, if the snapshotter also removes the cache, it will remove the same blob files that are in use by image2. The issue might not appear directly du to image2 nydusd keeping a fd open on the blob files. However, a reboot will lead image2 to have missing files.

Additionally, this issue was also happening with the index and referrer detect feature, because these features also create an inherent mismatch between the layers id stored in containerd and the ones stored on disk.

Note: this PR is addressing a situation which has a low change of occurring because it needs quite a bit of coincidences to be visible:
- 2 nydus images which have some layers which are the same but are not in the same order (so the chainID will be different) OR 1 regular nydus image and 1 nydus OCI-compatible image which have at least 1 layer in common (their chainID will necessarily be different due to the design of OCI-compatible images)
- one of the regular nydus image is deleted from the host
- enough time has passed so that the registry credentials from the other image have now expired
- nydusd crashes OR the kernel crashes, causing a new boot. The remaining image will fail to fetch its missing files on restart

To solve this, we stop removing the cache blobs in the snapshotter Remove call. And rather let the `cleanupUnusedCacheBlobs` logic introduced in https://github.com/DataDog/nydus-snapshotter/pull/10 in the Cleanup method decide whether a blob is now unused and should be removed.

The following diagram illustrates the issue 
```mermaid
sequenceDiagram
      participant Reg as Registry<br/>┌─ Image A (sha256:abc123)<br/>│  └─ Layer1 → Layer2<br/>└─ Image B (sha256:def456)<br/>   └─ Layer2 → Layer3
      participant C as Containerd
      participant NS as Nydus Snapshotter
      participant Nydusd as nydusd
      participant Cache as Cache Directory
      participant Disk as Containerd State

      Note over Reg,Disk: Pull Image A (Layer1 → Layer2)
      C->>NS: Prepare Layer1
      NS-->>C: Remote mount
      C->>Disk: Track ChainID(Layer1)
      C->>NS: Prepare Layer2
      NS-->>C: Remote mount
      C->>Disk: Track ChainID(Layer1, Layer2)
      C->>NS: Mount Image A
      NS->>Nydusd: Start nydusd for Image A
      Nydusd->>Reg: Download blob sha256:layer1-digest
      Nydusd->>Cache: Store blob sha256:layer1-digest
      Nydusd->>Reg: Download blob sha256:layer2-digest
      Nydusd->>Cache: Store blob sha256:layer2-digest
      Note over Cache,Disk: Cache: [layer1-digest, layer2-digest]<br/>Containerd: [ChainID_A_L1, ChainID_A_L2]

      Note over Reg,Disk: Pull Image B (Layer2 → Layer3)
      C->>NS: Prepare Layer2
      NS-->>C: Remote mount
      C->>Disk: Track ChainID(Layer2)
      C->>NS: Prepare Layer3
      NS-->>C: Remote mount
      C->>Disk: Track ChainID(Layer2, Layer3)
      C->>NS: Mount Image B
      NS->>Nydusd: Start nydusd for Image B
      Nydusd->>Cache: Check blob sha256:layer2-digest
      Cache-->>Nydusd: ✓ Already exists!
      Nydusd->>Reg: Download blob sha256:layer3-digest
      Nydusd->>Cache: Store blob sha256:layer3-digest
      Note over Cache,Disk: Cache: [layer1-digest, layer2-digest, layer3-digest]<br/>Containerd: [ChainID_A_L1, ChainID_A_L2, ChainID_B_L2, ChainID_B_L3]<br/>⚠️ layer2-digest used by both images!

      Note over Reg,Disk: Remove Image A - PROBLEM
      C->>NS: Remove ChainID_A_L2
      NS->>Cache: Delete blob sha256:layer2-digest
      Cache-->>NS: ✓ Deleted
      NS-->>C: Removed
      C->>Disk: Remove tracking ChainID_A_L2
      Note over Cache,Disk: ⚠️ BUG!<br/>Cache: [layer1-digest, layer3-digest]<br/>Image B still needs layer2-digest!<br/>Image B will fail on nydusd restart!

      Note over Reg,Disk: Remove Image A - SOLUTION
      C->>NS: Remove ChainID_A_L2
      NS->>NS: Skip cache deletion<br/>Defer to Cleanup GC
      NS-->>C: Removed
      C->>Disk: Remove tracking ChainID_A_L2
      Note over Cache,Disk: ✓ Safe state:<br/>Cache: [layer1-digest, layer2-digest, layer3-digest]<br/>Image B still works!

      Note over Reg,Disk: Later: Snapshotter Cleanup (GC)
      C->>NS: Cleanup
      NS->>Nydusd: Query files in-use for active RAFS instances
      Nydusd-->>NS: In-use blobs:<br/>[sha256:layer2-digest, sha256:layer3-digest]
      NS->>Cache: List all cache blobs
      Cache-->>NS: All blobs:<br/>[sha256:layer1-digest, sha256:layer2-digest,<br/>sha256:layer3-digest]
      NS->>NS: Compare: cache vs in-use<br/>Find orphans: [layer1-digest]
      NS->>Cache: Delete orphaned blobs [layer1-digest]
      Cache-->>NS: ✓ Removed
      Note over Cache,Disk: ✓ Correct cleanup:<br/>Cache: [layer2-digest, layer3-digest]<br/>Only truly unused blobs removed
```