### PR TITLE
[auth] Fix 0s cache duration override in kubelet provider

### DIFF
--- a/pkg/auth/kubelet.go
+++ b/pkg/auth/kubelet.go
@@ -328,7 +328,7 @@ func (p *KubeletProvider) bestMatchedCred(image string) *kubeletCredential {
 // the per-response CacheDuration takes precedence,
 // otherwise the plugin's DefaultCacheDuration is used.
 func resolveCacheDuration(resp *credentialproviderv1.CredentialProviderResponse, plugin *kubeletconfigv1.CredentialProvider) time.Duration {
-	if resp.CacheDuration != nil {
+	if resp.CacheDuration != nil && resp.CacheDuration.Duration >= 0 {
 		return resp.CacheDuration.Duration
 	}
 	return plugin.DefaultCacheDuration.Duration

--- a/pkg/auth/kubelet.go
+++ b/pkg/auth/kubelet.go
@@ -325,10 +325,10 @@ func (p *KubeletProvider) bestMatchedCred(image string) *kubeletCredential {
 }
 
 // resolveCacheDuration picks the effective TTL from a plugin response:
-// the per-response CacheDuration takes precedence if it is positive,
+// the per-response CacheDuration takes precedence,
 // otherwise the plugin's DefaultCacheDuration is used.
 func resolveCacheDuration(resp *credentialproviderv1.CredentialProviderResponse, plugin *kubeletconfigv1.CredentialProvider) time.Duration {
-	if resp.CacheDuration != nil && resp.CacheDuration.Duration > 0 {
+	if resp.CacheDuration != nil {
 		return resp.CacheDuration.Duration
 	}
 	return plugin.DefaultCacheDuration.Duration

--- a/pkg/auth/kubelet_test.go
+++ b/pkg/auth/kubelet_test.go
@@ -880,6 +880,14 @@ func TestKubeletProviderRegistryCache(t *testing.T) {
 			defaultTTL:       0,
 			wantCachedOnNext: false,
 		},
+		{
+			name:             "response zero TTL overrides non-zero default",
+			pluginName:       "override-ttl-plugin",
+			cfgName:          "override-ttl-config.yaml",
+			responseTTL:      "0s",
+			defaultTTL:       10 * time.Minute,
+			wantCachedOnNext: false,
+		},
 	}
 
 	_, binDir := setupKubeletProvider(t)

--- a/pkg/auth/kubelet_test.go
+++ b/pkg/auth/kubelet_test.go
@@ -888,6 +888,14 @@ func TestKubeletProviderRegistryCache(t *testing.T) {
 			defaultTTL:       10 * time.Minute,
 			wantCachedOnNext: false,
 		},
+		{
+			name:             "response negative TTL uses default TTL",
+			pluginName:       "negative-ttl-plugin",
+			cfgName:          "negative-ttl-config.yaml",
+			responseTTL:      "-1s",
+			defaultTTL:       10 * time.Minute,
+			wantCachedOnNext: true,
+		},
 	}
 
 	_, binDir := setupKubeletProvider(t)


### PR DESCRIPTION
When a credential provider plugin returned cacheDuration: 0s to opt out of caching, the `> 0` guard in resolveCacheDuration caused the response value to be ignored, falling through to the plugin's defaultCacheDuration instead. This meant credentials were cached even when the plugin explicitly requested they should not be.

Remove the `> 0` check so that any explicitly-set response CacheDuration (including zero) takes precedence over the default, matching the Kubernetes kubelet behavior.