### PR TITLE
[remote] Add skip_http_fallback config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -215,6 +215,7 @@ type RemoteConfig struct {
 	AuthConfig         AuthConfig    `toml:"auth"`
 	ConvertVpcRegistry bool          `toml:"convert_vpc_registry"`
 	SkipSSLVerify      bool          `toml:"skip_ssl_verify"`
+	SkipHTTPFallback   bool          `toml:"skip_http_fallback"`
 	MirrorsConfig      MirrorsConfig `toml:"mirrors_config"`
 }
 

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -83,6 +83,7 @@ type BackendConfig struct {
 	BlobURLScheme      string         `json:"blob_url_scheme,omitempty"`
 	BlobRedirectedHost string         `json:"blob_redirected_host,omitempty"`
 	Mirrors            []MirrorConfig `json:"mirrors,omitempty"`
+	SkipHTTPFallback   bool           `json:"skip_http_fallback,omitempty"`
 
 	// Shared by oss and s3 backend configs
 	EndPoint        string `json:"endpoint,omitempty"`

--- a/pkg/index/detector.go
+++ b/pkg/index/detector.go
@@ -32,9 +32,9 @@ type detector struct {
 	remote *remote.Remote
 }
 
-func newDetector(keyChain *auth.PassKeyChain, insecure bool) *detector {
+func newDetector(keyChain *auth.PassKeyChain, insecure, skipHTTPFallback bool) *detector {
 	return &detector{
-		remote: remote.New(keyChain, insecure),
+		remote: remote.New(keyChain, insecure, skipHTTPFallback),
 	}
 }
 

--- a/pkg/index/manager.go
+++ b/pkg/index/manager.go
@@ -19,16 +19,18 @@ import (
 )
 
 type Manager struct {
-	insecure bool
-	cache    *lru.Cache
-	sg       singleflight.Group
+	insecure         bool
+	skipHTTPFallback bool
+	cache            *lru.Cache
+	sg               singleflight.Group
 }
 
-func NewManager(insecure bool) *Manager {
+func NewManager(insecure, skipHTTPFallback bool) *Manager {
 	manager := Manager{
-		insecure: insecure,
-		cache:    lru.New(500),
-		sg:       singleflight.Group{},
+		insecure:         insecure,
+		skipHTTPFallback: skipHTTPFallback,
+		cache:            lru.New(500),
+		sg:               singleflight.Group{},
 	}
 
 	return &manager
@@ -54,7 +56,7 @@ func (manager *Manager) CheckIndexAlternative(ctx context.Context, ref string, m
 		}
 
 		// No LRU cache found, try to detect nydus alternative in index manifest.
-		detector := newDetector(keyChain, manager.insecure)
+		detector := newDetector(keyChain, manager.insecure, manager.skipHTTPFallback)
 		metaLayer, err := detector.checkIndexAlternative(ctx, ref, manifestDigest)
 		if err != nil {
 			// Cache empty result to avoid repeated failures.
@@ -95,6 +97,6 @@ func (manager *Manager) TryFetchMetadata(ctx context.Context, ref string, manife
 		return errors.Wrap(err, "get key chain")
 	}
 
-	detector := newDetector(keyChain, manager.insecure)
+	detector := newDetector(keyChain, manager.insecure, manager.skipHTTPFallback)
 	return detector.fetchMetadata(ctx, ref, *metaLayer, metadataPath)
 }

--- a/pkg/index/manager_test.go
+++ b/pkg/index/manager_test.go
@@ -24,7 +24,7 @@ func TestCheckIndexAlternative(t *testing.T) {
 	}
 
 	t.Run("cache hit, nydus present", func(t *testing.T) {
-		manager := NewManager(false)
+		manager := NewManager(false, false)
 		manager.cache.Add(manifestDigest, *expectedDesc)
 
 		result, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
@@ -34,7 +34,7 @@ func TestCheckIndexAlternative(t *testing.T) {
 	})
 
 	t.Run("cache hit, no nydus", func(t *testing.T) {
-		manager := NewManager(false)
+		manager := NewManager(false, false)
 		manager.cache.Add(manifestDigest, nil)
 
 		_, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)

--- a/pkg/referrer/manager.go
+++ b/pkg/referrer/manager.go
@@ -19,16 +19,18 @@ import (
 )
 
 type Manager struct {
-	insecure bool
-	cache    *lru.Cache
-	sg       singleflight.Group
+	insecure         bool
+	skipHTTPFallback bool
+	cache            *lru.Cache
+	sg               singleflight.Group
 }
 
-func NewManager(insecure bool) *Manager {
+func NewManager(insecure, skipHTTPFallback bool) *Manager {
 	manager := Manager{
-		insecure: insecure,
-		cache:    lru.New(500),
-		sg:       singleflight.Group{},
+		insecure:         insecure,
+		skipHTTPFallback: skipHTTPFallback,
+		cache:            lru.New(500),
+		sg:               singleflight.Group{},
 	}
 
 	return &manager
@@ -51,7 +53,7 @@ func (manager *Manager) CheckReferrer(ctx context.Context, ref string, manifestD
 
 		// No LRU cache found, try to fetch referrers and parse out
 		// the nydus metadata layer descriptor.
-		referrer := newReferrer(keyChain, manager.insecure)
+		referrer := newReferrer(keyChain, manager.insecure, manager.skipHTTPFallback)
 		metaLayer, err := referrer.checkReferrer(ctx, ref, manifestDigest)
 		if err != nil {
 			return nil, errors.Wrap(err, "check referrer")
@@ -83,6 +85,6 @@ func (manager *Manager) TryFetchMetadata(ctx context.Context, ref string, manife
 		return errors.Wrap(err, "get key chain")
 	}
 
-	referrer := newReferrer(keyChain, manager.insecure)
+	referrer := newReferrer(keyChain, manager.insecure, manager.skipHTTPFallback)
 	return referrer.fetchMetadata(ctx, ref, *metaLayer, metadataPath)
 }

--- a/pkg/referrer/referrer.go
+++ b/pkg/referrer/referrer.go
@@ -31,9 +31,9 @@ type referrer struct {
 	remote *remote.Remote
 }
 
-func newReferrer(keyChain *auth.PassKeyChain, insecure bool) *referrer {
+func newReferrer(keyChain *auth.PassKeyChain, insecure, skipHTTPFallback bool) *referrer {
 	return &referrer{
-		remote: remote.New(keyChain, insecure),
+		remote: remote.New(keyChain, insecure, skipHTTPFallback),
 	}
 }
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -47,9 +47,12 @@ type Remote struct {
 	// withPlainHTTP attempts to request the remote registry using http instead
 	// of https.
 	withPlainHTTP bool
+	// skipHTTPFallback prevents automatic fallback from HTTPS to plain HTTP
+	// when connection errors occur.
+	skipHTTPFallback bool
 }
 
-func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
+func New(keyChain *auth.PassKeyChain, insecure, skipHTTPFallback bool) *Remote {
 	// nolint:unparam
 	credFunc := func(string) (string, string, error) {
 		if keyChain == nil {
@@ -88,12 +91,16 @@ func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
 	}
 
 	return &Remote{
-		resolverFunc:  resolverFunc,
-		withPlainHTTP: false,
+		resolverFunc:     resolverFunc,
+		withPlainHTTP:    false,
+		skipHTTPFallback: skipHTTPFallback,
 	}
 }
 
 func (remote *Remote) RetryWithPlainHTTP(ref string, err error) bool {
+	if remote.skipHTTPFallback {
+		return false
+	}
 	retry := err != nil && (isErrHTTPResponseToHTTPSClient(err) || isErrConnectionRefused(err))
 	if !retry {
 		return false

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package remote
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryWithPlainHTTP(t *testing.T) {
+	const ref = "docker.io/library/nginx:latest"
+
+	httpsErr := fmt.Errorf("Get https://docker.io/v2/: http: server gave HTTP response to HTTPS client")
+	connRefusedErr := fmt.Errorf("Get https://docker.io/v2/: dial tcp connect: connection refused")
+	otherErr := fmt.Errorf("some unrelated error")
+
+	tests := []struct {
+		name             string
+		skipHTTPFallback bool
+		err              error
+		expected         bool
+	}{
+		{
+			name:             "fallback on HTTPS-to-HTTP error",
+			skipHTTPFallback: false,
+			err:              httpsErr,
+			expected:         true,
+		},
+		{
+			name:             "fallback on connection refused",
+			skipHTTPFallback: false,
+			err:              connRefusedErr,
+			expected:         true,
+		},
+		{
+			name:             "no fallback on unrelated error",
+			skipHTTPFallback: false,
+			err:              otherErr,
+			expected:         false,
+		},
+		{
+			name:             "no fallback when nil error",
+			skipHTTPFallback: false,
+			err:              nil,
+			expected:         false,
+		},
+		{
+			name:             "skip fallback even on HTTPS-to-HTTP error",
+			skipHTTPFallback: true,
+			err:              httpsErr,
+			expected:         false,
+		},
+		{
+			name:             "skip fallback even on connection refused",
+			skipHTTPFallback: true,
+			err:              connRefusedErr,
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := &Remote{
+				skipHTTPFallback: tt.skipHTTPFallback,
+			}
+			result := remote.RetryWithPlainHTTP(ref, tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -63,6 +63,7 @@ type Manager struct {
 	cacheDirPath         string
 	nydusImagePath       string
 	insecure             bool
+	skipHTTPFallback     bool
 	validateDiffID       bool // whether to validate digest for uncompressed content
 	checkTarfsHint       bool // whether to rely on tarfs hint annotation
 	maxConcurrentProcess int64
@@ -84,12 +85,13 @@ type snapshotStatus struct {
 	cancel          context.CancelFunc
 }
 
-func NewManager(insecure, checkTarfsHint bool, cacheDirPath, nydusImagePath string, maxConcurrentProcess int64) *Manager {
+func NewManager(insecure, skipHTTPFallback, checkTarfsHint bool, cacheDirPath, nydusImagePath string, maxConcurrentProcess int64) *Manager {
 	return &Manager{
 		snapshotMap:          map[string]*snapshotStatus{},
 		cacheDirPath:         cacheDirPath,
 		nydusImagePath:       nydusImagePath,
 		insecure:             insecure,
+		skipHTTPFallback:     skipHTTPFallback,
 		validateDiffID:       true,
 		checkTarfsHint:       checkTarfsHint,
 		maxConcurrentProcess: maxConcurrentProcess,
@@ -335,7 +337,7 @@ func (t *Manager) blobProcess(ctx context.Context, wg *sync.WaitGroup, snapshotI
 		epilog(err, "create key chain for connection")
 		return err
 	}
-	remote := remote.New(keyChain, t.insecure)
+	remote := remote.New(keyChain, t.insecure, t.skipHTTPFallback)
 	rc, _, err := t.getBlobStream(ctx, remote, ref, layerDigest)
 	if err != nil && remote.RetryWithPlainHTTP(ref, err) {
 		rc, _, err = t.getBlobStream(ctx, remote, ref, layerDigest)
@@ -768,7 +770,7 @@ func (t *Manager) CheckTarfsHintAnnotation(ctx context.Context, ref string, mani
 	if err != nil {
 		return false, err
 	}
-	remote := remote.New(keyChain, t.insecure)
+	remote := remote.New(keyChain, t.insecure, t.skipHTTPFallback)
 
 	handle := func() (bool, error) {
 		if tarfsHint, ok := t.tarfsHintCache.Get(ref); ok {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -97,6 +97,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		}
 	}
 
+	skipHTTPFallback := cfg.RemoteConfig.SkipHTTPFallback
 	var skipSSLVerify bool
 	var daemonConfig *daemonconfig.DaemonConfig
 	fsDriver := config.GetFsDriver()
@@ -230,17 +231,17 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	opts = append(opts, filesystem.WithCacheManager(cacheMgr))
 
 	if cfg.Experimental.EnableIndexDetect {
-		indexMgr := index.NewManager(skipSSLVerify)
+		indexMgr := index.NewManager(skipSSLVerify, skipHTTPFallback)
 		opts = append(opts, filesystem.WithIndexManager(indexMgr))
 	}
 
 	if cfg.Experimental.EnableReferrerDetect {
-		referrerMgr := referrer.NewManager(skipSSLVerify)
+		referrerMgr := referrer.NewManager(skipSSLVerify, skipHTTPFallback)
 		opts = append(opts, filesystem.WithReferrerManager(referrerMgr))
 	}
 
 	if cfg.Experimental.TarfsConfig.EnableTarfs {
-		tarfsMgr := tarfs.NewManager(skipSSLVerify, cfg.Experimental.TarfsConfig.TarfsHint,
+		tarfsMgr := tarfs.NewManager(skipSSLVerify, skipHTTPFallback, cfg.Experimental.TarfsConfig.TarfsHint,
 			cacheConfig.CacheDir, cfg.DaemonConfig.NydusImagePath,
 			int64(cfg.Experimental.TarfsConfig.MaxConcurrentProc))
 		opts = append(opts, filesystem.WithTarfsManager(tarfsMgr))


### PR DESCRIPTION
Allow the snapshotter to not downgrade https connections.
Also support for the same flag for nydusd (implementation in https://github.com/DataDog/nydus/pull/18/)

Tested locally that the config was propagated correctly using a log:
```
INFO[2026-03-31T18:30:01.370244344+02:00] Logger successfully set up. Proceeding to process nydus-snapshotter configurations
INFO[2026-03-31T18:30:01.370282811+02:00] Start nydus-snapshotter. Version: v0.15.11-32-gfc10f5d.m, PID: 1439407, FsDriver: fusedev, DaemonMode: multiple
INFO[2026-03-31T18:30:01.374603367+02:00] skip http fallback: true
```