### PR TITLE
[snapshot] Add config option for volatile overlayfs (#731)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,10 @@ type SnapshotConfig struct {
 	NydusOverlayFSPath   string `toml:"nydus_overlayfs_path"`
 	EnableKataVolume     bool   `toml:"enable_kata_volume"`
 	SyncRemove           bool   `toml:"sync_remove"`
+	// EnableOverlayfsVolatile globally enables the "volatile" overlayfs mount option
+	// on all writable snapshots. This skips sync on the upper layer, improving
+	// write performance for ephemeral container filesystems at the cost of crash consistency.
+	EnableOverlayfsVolatile bool `toml:"enable_overlayfs_volatile"`
 }
 
 // Configure cache manager that manages the cache files lifecycle

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -100,6 +100,11 @@ nydus_overlayfs_path = "nydus-overlayfs"
 enable_kata_volume = false
 # Whether to remove resources when a snapshot is removed
 sync_remove = false
+# Globally enable the "volatile" overlayfs mount option on all writable snapshots.
+# This skips sync on the upper layer, improving write performance for ephemeral
+# container filesystems. Safe for most workloads where the writable layer does not
+# need to survive a crash.
+enable_overlayfs_volatile = false
 
 [cache_manager]
 # Disable or enable recyclebin

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -52,16 +52,17 @@ import (
 var _ snapshots.Snapshotter = &snapshotter{}
 
 type snapshotter struct {
-	root                 string
-	nydusdPath           string
-	ms                   *storage.MetaStore // Storing snapshots' state, parentage and other metadata
-	fs                   *filesystem.Filesystem
-	cgroupManager        *cgroup.Manager
-	enableNydusOverlayFS bool
-	nydusOverlayFSPath   string
-	enableKataVolume     bool
-	syncRemove           bool
-	cleanupOnClose       bool
+	root                    string
+	nydusdPath              string
+	ms                      *storage.MetaStore // Storing snapshots' state, parentage and other metadata
+	fs                      *filesystem.Filesystem
+	cgroupManager           *cgroup.Manager
+	enableNydusOverlayFS    bool
+	nydusOverlayFSPath      string
+	enableKataVolume        bool
+	syncRemove              bool
+	cleanupOnClose          bool
+	enableOverlayfsVolatile bool
 }
 
 func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapshots.Snapshotter, error) {
@@ -300,16 +301,17 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	return &snapshotter{
-		root:                 cfg.Root,
-		nydusdPath:           cfg.DaemonConfig.NydusdPath,
-		ms:                   ms,
-		syncRemove:           syncRemove,
-		fs:                   nydusFs,
-		cgroupManager:        cgroupMgr,
-		enableNydusOverlayFS: cfg.SnapshotsConfig.EnableNydusOverlayFS,
-		nydusOverlayFSPath:   cfg.SnapshotsConfig.NydusOverlayFSPath,
-		enableKataVolume:     cfg.SnapshotsConfig.EnableKataVolume,
-		cleanupOnClose:       cfg.CleanupOnClose,
+		root:                    cfg.Root,
+		nydusdPath:              cfg.DaemonConfig.NydusdPath,
+		ms:                      ms,
+		syncRemove:              syncRemove,
+		fs:                      nydusFs,
+		cgroupManager:           cgroupMgr,
+		enableNydusOverlayFS:    cfg.SnapshotsConfig.EnableNydusOverlayFS,
+		nydusOverlayFSPath:      cfg.SnapshotsConfig.NydusOverlayFSPath,
+		enableKataVolume:        cfg.SnapshotsConfig.EnableKataVolume,
+		enableOverlayfsVolatile: cfg.SnapshotsConfig.EnableOverlayfsVolatile,
+		cleanupOnClose:          cfg.CleanupOnClose,
 	}, nil
 }
 
@@ -1093,7 +1095,7 @@ func (o *snapshotter) mountProxy(ctx context.Context, s storage.Snapshot) ([]mou
 // `s` and `id` can represent a different layer, it's useful when View an image
 func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string, s storage.Snapshot, id, key string) ([]mount.Mount, error) {
 	var overlayOptions []string
-	if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
+	if _, ok := labels[label.OverlayfsVolatileOpt]; ok || o.enableOverlayfsVolatile {
 		overlayOptions = append(overlayOptions, "volatile")
 	}
 
@@ -1163,7 +1165,7 @@ func (o *snapshotter) mountNative(ctx context.Context, labels map[string]string,
 			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
 			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
 		)
-		if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
+		if _, ok := labels[label.OverlayfsVolatileOpt]; ok || o.enableOverlayfsVolatile {
 			options = append(options, "volatile")
 		}
 	} else if len(s.ParentIDs) == 1 {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -224,3 +224,49 @@ func TestMountNative(t *testing.T) {
 		})
 	}
 }
+
+func TestMountNativeConfigVolatile(t *testing.T) {
+	snapshotterRoot := "/var/lib/containerd/snapshotter"
+	s := &snapshotter{
+		root:                    snapshotterRoot,
+		enableOverlayfsVolatile: true,
+	}
+
+	ctx := context.Background()
+
+	t.Run("active snapshot gets volatile from config", func(t *testing.T) {
+		snap := storage.Snapshot{
+			ID:        "snap1",
+			Kind:      snapshots.KindActive,
+			ParentIDs: []string{"parent1", "parent2"},
+		}
+		mounts, err := s.mountNative(ctx, nil, snap)
+		require.NoError(t, err)
+		require.Len(t, mounts, 1)
+		assert.Contains(t, mounts[0].Options, "volatile")
+	})
+
+	t.Run("view snapshot does not get volatile from config", func(t *testing.T) {
+		snap := storage.Snapshot{
+			ID:        "snap2",
+			Kind:      snapshots.KindView,
+			ParentIDs: []string{"parent1", "parent2"},
+		}
+		mounts, err := s.mountNative(ctx, nil, snap)
+		require.NoError(t, err)
+		require.Len(t, mounts, 1)
+		assert.NotContains(t, mounts[0].Options, "volatile")
+	})
+
+	t.Run("committed snapshot does not get volatile from config", func(t *testing.T) {
+		snap := storage.Snapshot{
+			ID:        "snap3",
+			Kind:      snapshots.KindCommitted,
+			ParentIDs: []string{"parent1", "parent2"},
+		}
+		mounts, err := s.mountNative(ctx, nil, snap)
+		require.NoError(t, err)
+		require.Len(t, mounts, 1)
+		assert.NotContains(t, mounts[0].Options, "volatile")
+	})
+}


### PR DESCRIPTION
Add `enable_overlayfs_volatile` to the snapshot config so operators can globally enable the volatile overlayfs mount option on all writable layers without needing to inject snapshot labels through the container runtime stack.

The volatile option skips sync on the upper layer, improving write performance for ephemeral container filesystems. This is a safe trade-off for most workloads where the writable layer does not need to survive a crash.