### PR TITLE
[local] Remove duplicate startCredentialRenewal call

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -182,10 +182,6 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		fsManagers = append(fsManagers, proxyManager)
 	}
 
-	if interval := cfg.RemoteConfig.AuthConfig.CredentialRenewalInterval; interval > 0 {
-		startCredentialRenewal(ctx, interval, fsManagers)
-	}
-
 	metricServer, err := metrics.NewServer(
 		ctx,
 		metrics.WithProcessManagers(fsManagers),


### PR DESCRIPTION
startCredentialRenewal was called twice in NewSnapshotter: once before NewFileSystem and once after. The second call (post-Recover) is the correct one since daemon caches are only populated after Manager.Recover(). The first call caused two concurrent renewal goroutines iterating the same managers, leading to duplicate plugin executions and redundant credential renewals for every image.